### PR TITLE
Fixed Radar.DetectActor patch

### DIFF
--- a/JesterAI/JesterAI.cs
+++ b/JesterAI/JesterAI.cs
@@ -335,11 +335,9 @@ namespace Jester
         }
 
 
-        [HarmonyPatch(typeof(Radar), nameof(Radar.DetectActor), new Type[] {typeof(Actor) })]
+        [HarmonyPatch(typeof(Radar), nameof(Radar.DetectActor), new Type[] {typeof(Actor), typeof(float), typeof(TargetIdentity)})]
         public static class PatchDetectActor
         {
-            
-
             public static void Postfix(Radar __instance, ref Actor a)
             {
                 if (!jesteraiobj)


### PR DESCRIPTION
An update added a few more parameters to it, added the types to the patch. I assume it would be more update resistant without the parameter specification but I don't know, this works for now at least.